### PR TITLE
Show checkout failure reasons in cart

### DIFF
--- a/Library-Management-System/src/main/java/com/csc325/librarymanagementsystem/controller/CartController.java
+++ b/Library-Management-System/src/main/java/com/csc325/librarymanagementsystem/controller/CartController.java
@@ -1,6 +1,7 @@
 package com.csc325.librarymanagementsystem.controller;
 
 import com.csc325.librarymanagementsystem.data.FirebaseContext;
+import com.csc325.librarymanagementsystem.exception.CheckoutException;
 import com.csc325.librarymanagementsystem.model.Book;
 import com.csc325.librarymanagementsystem.model.CheckoutConfirmation;
 import com.csc325.librarymanagementsystem.service.CartService;
@@ -18,9 +19,6 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class CartController {
 
@@ -157,10 +155,6 @@ public class CartController {
                     Session.getCart()
             );
 
-            if (confirmation == null) {
-                throw new Exception("Checkout failed.");
-            }
-
             refreshCart();
 
             messageLabel.setText(
@@ -168,10 +162,13 @@ public class CartController {
                             + confirmation.getConfirmationNumber()
             );
 
+        } catch (CheckoutException e) {
+
+            messageLabel.setText(e.getMessage());
+
         } catch (Exception e) {
 
-            messageLabel.setText("Checkout failed.");
-
+            messageLabel.setText("Checkout failed. Please try again.");
             e.printStackTrace();
         }
     }

--- a/Library-Management-System/src/main/java/com/csc325/librarymanagementsystem/service/CartService.java
+++ b/Library-Management-System/src/main/java/com/csc325/librarymanagementsystem/service/CartService.java
@@ -1,6 +1,7 @@
 package com.csc325.librarymanagementsystem.service;
 
 import com.csc325.librarymanagementsystem.data.FirebaseContext;
+import com.csc325.librarymanagementsystem.exception.CheckoutException;
 import com.csc325.librarymanagementsystem.model.Book;
 import com.csc325.librarymanagementsystem.model.Cart;
 import com.csc325.librarymanagementsystem.model.CheckoutConfirmation;
@@ -81,9 +82,44 @@ public class CartService {
         return true;
     }
 
-    public CheckoutConfirmation checkout(User user, Cart cart) {
-        if (!canCheckout(user, cart)) {
-            return null;
+    public CheckoutConfirmation checkout(User user, Cart cart) throws CheckoutException {
+
+        if (user == null) {
+            throw new CheckoutException("Checkout failed: no user is currently logged in.");
+        }
+
+        if (cart == null || cart.isEmpty()) {
+            throw new CheckoutException("Checkout failed: your cart is empty.");
+        }
+
+        int activeLoanCount = firebaseContext.loans()
+                .getActiveLoans(user.getUserId())
+                .size();
+
+        if (activeLoanCount + cart.size() > MAX_CHECKOUT_LIMIT) {
+            throw new CheckoutException(
+                    "Checkout failed: you can only have "
+                            + MAX_CHECKOUT_LIMIT
+                            + " books checked out at once."
+            );
+        }
+
+        for (Book book : cart.getBooks()) {
+            if (book == null) {
+                throw new CheckoutException("Checkout failed: one of the books in your cart is invalid.");
+            }
+
+            if (book.getBookId() == null || book.getBookId().isBlank()) {
+                throw new CheckoutException("Checkout failed: one of the books is missing a book ID.");
+            }
+
+            if (book.getQuantity() <= 0) {
+                throw new CheckoutException(
+                        "Checkout failed: "
+                                + book.getTitle()
+                                + " is currently unavailable."
+                );
+            }
         }
 
         List<String> bookIds = cart.getBooks()
@@ -99,11 +135,16 @@ public class CartService {
                 bookIds,
                 checkoutDate
         );
+
         for (Book book : cart.getBooks()) {
             boolean stockUpdated = firebaseContext.adjustStock(book.getBookId(), -1);
 
             if (!stockUpdated) {
-                return null;
+                throw new CheckoutException(
+                        "Checkout failed: could not update stock for "
+                                + book.getTitle()
+                                + "."
+                );
             }
 
             Calendar dueDateCalendar = Calendar.getInstance();
@@ -123,7 +164,11 @@ public class CartService {
             boolean loanRecorded = firebaseContext.loans().recordLoan(loan);
 
             if (!loanRecorded) {
-                return null;
+                throw new CheckoutException(
+                        "Checkout failed: could not create loan for "
+                                + book.getTitle()
+                                + "."
+                );
             }
         }
 
@@ -131,7 +176,7 @@ public class CartService {
                 .recordCheckoutConfirmation(confirmation);
 
         if (!confirmationRecorded) {
-            return null;
+            throw new CheckoutException("Checkout failed: could not save checkout confirmation.");
         }
 
         cart.clearCart();

--- a/Library-Management-System/src/test/java/com/csc325/librarymanagementsystem/service/CartServiceTest.java
+++ b/Library-Management-System/src/test/java/com/csc325/librarymanagementsystem/service/CartServiceTest.java
@@ -1,9 +1,9 @@
 package com.csc325.librarymanagementsystem.service;
 
 import com.csc325.librarymanagementsystem.data.FakeData;
+import com.csc325.librarymanagementsystem.exception.CheckoutException;
 import com.csc325.librarymanagementsystem.model.Book;
 import com.csc325.librarymanagementsystem.model.Cart;
-import com.csc325.librarymanagementsystem.model.CheckoutConfirmation;
 import com.csc325.librarymanagementsystem.model.User;
 import org.junit.jupiter.api.Test;
 
@@ -131,13 +131,16 @@ class CartServiceTest {
     }
 
     @Test
-    void checkoutShouldReturnNullForEmptyCart() {
+    void checkoutShouldThrowExceptionForEmptyCart() {
         User user = getTestUser();
         Cart cart = new Cart();
 
-        CheckoutConfirmation confirmation = cartService.checkout(user, cart);
+        CheckoutException exception = assertThrows(
+                CheckoutException.class,
+                () -> cartService.checkout(user, cart)
+        );
 
-        assertNull(confirmation);
+        assertEquals("Checkout failed: your cart is empty.", exception.getMessage());
     }
 
 }


### PR DESCRIPTION
Updated the checkout flow so failed checkouts show a specific reason to the user instead of only returning null/generic failure.

Changes:
- Updated CartService to throw CheckoutException with clear failure messages.
- Updated CartController to catch CheckoutException and display the message in the cart screen.
- Updated CartServiceTest to use assertThrows for the empty-cart checkout case.
- Verified CartServiceTest passes with 10/10 tests.
- Manually tested the cart checkout screen and confirmed the checkout limit error message displays correctly.